### PR TITLE
Use docker offical build action

### DIFF
--- a/.github/workflows/build-and-push-Docker-image.yml
+++ b/.github/workflows/build-and-push-Docker-image.yml
@@ -1,3 +1,5 @@
+name: Build and push docker image
+
 on:
   workflow_call:
     inputs:
@@ -10,33 +12,41 @@ on:
     outputs:
       full-image-name:
         description: "Full pushed image name including host/registry, name, and tag"
-        value: ${{ jobs.docker-build.outputs.full-image-name }}
+        value: ${{ jobs.docker.outputs.full-image-name }}
+
 jobs:
-  docker-build:
+  docker:
     runs-on: ubuntu-latest
     permissions:
       packages: write
       contents: read
     timeout-minutes: 25
     outputs:
-      full-image-name: ${{ steps.push-image.outputs.full-image-name }}
+      full-image-name: ${{ steps.image-name.outputs.full-image-name }}
 
     steps:
-      - name: Checkout
-        # https://github.com/actions/checkout
-        uses: actions/checkout@v3
 
-      - name: Build Docker image
-        run: docker build . --file Dockerfile --tag ${{ inputs.image-name }}
-
-      - name: Log in to registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
-
-      - name: Push image
-        id: push-image
+      - name: Define image name
+        id: image-name
         run: |
           full_image_name="ghcr.io/${{ github.repository_owner }}/${{ inputs.image-name }}:${{ inputs.image-tag }}"
           full_image_name=$(echo $full_image_name | tr '[A-Z]' '[a-z]')
-          docker tag ${{ inputs.image-name }} $full_image_name
-          docker push $full_image_name
-          echo "full-image-name=$full_image_name" >> $GITHUB_OUTPUT
+          echo "full-image-name=$full_image_name" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          tags: ${{ steps.image-name.outputs.full-image-name }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=min


### PR DESCRIPTION
using https://github.com/docker/build-push-action/ which enables multi-architecture builds and pushing to multiple registries, as well as other features available in buildx (such as build-time secrets)