### PR TITLE
Add .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+**/.git
+**/.github
+**/.gitignore
+**/Dockerfile
+**/*.md
+**/*.Rproj


### PR DESCRIPTION
reduce build context by ignoring anything that isn't actually used in the docker image