### PR TITLE
Feature/multistage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+**/.git
+**/.github
+**/.gitignore
+**/Dockerfile
+**/*.md
+**/*.Rproj

--- a/.github/workflows/build-and-push-Docker-image.yml
+++ b/.github/workflows/build-and-push-Docker-image.yml
@@ -50,3 +50,4 @@ jobs:
           tags: ${{ steps.image-name.outputs.full-image-name }}
           cache-from: type=gha
           cache-to: type=gha,mode=min
+          no-cache-filters: install-pacta

--- a/.github/workflows/build-and-push-Docker-image.yml
+++ b/.github/workflows/build-and-push-Docker-image.yml
@@ -1,3 +1,5 @@
+name: Build and push docker image
+
 on:
   workflow_call:
     inputs:
@@ -10,33 +12,41 @@ on:
     outputs:
       full-image-name:
         description: "Full pushed image name including host/registry, name, and tag"
-        value: ${{ jobs.docker-build.outputs.full-image-name }}
+        value: ${{ jobs.docker.outputs.full-image-name }}
+
 jobs:
-  docker-build:
+  docker:
     runs-on: ubuntu-latest
     permissions:
       packages: write
       contents: read
     timeout-minutes: 25
     outputs:
-      full-image-name: ${{ steps.push-image.outputs.full-image-name }}
+      full-image-name: ${{ steps.image-name.outputs.full-image-name }}
 
     steps:
-      - name: Checkout
-        # https://github.com/actions/checkout
-        uses: actions/checkout@v3
 
-      - name: Build Docker image
-        run: docker build . --file Dockerfile --tag ${{ inputs.image-name }}
-
-      - name: Log in to registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
-
-      - name: Push image
-        id: push-image
+      - name: Define image name
+        id: image-name
         run: |
           full_image_name="ghcr.io/${{ github.repository_owner }}/${{ inputs.image-name }}:${{ inputs.image-tag }}"
           full_image_name=$(echo $full_image_name | tr '[A-Z]' '[a-z]')
-          docker tag ${{ inputs.image-name }} $full_image_name
-          docker push $full_image_name
-          echo "full-image-name=$full_image_name" >> $GITHUB_OUTPUT
+          echo "full-image-name=$full_image_name" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          tags: ${{ steps.image-name.outputs.full-image-name }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=min

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,8 @@
 # https://packagemanager.posit.co/cran/__linux__/jammy/2023-10-30
 
 # set proper base image
-ARG PLATFORM="linux/amd64"
 ARG R_VERS="4.3.1"
-FROM --platform=$PLATFORM rocker/r-ver:$R_VERS
+FROM rocker/r-ver:$R_VERS
 
 # set Docker image labels
 LABEL org.opencontainers.image.source=https://github.com/RMI-PACTA/workflow.pacta

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN apt-get update \
 
 # set frozen CRAN repo
 ARG CRAN_REPO="https://packagemanager.posit.co/cran/__linux__/jammy/2023-10-30"
-RUN echo "options(repos = c(CRAN = '$CRAN_REPO'))" >> "${R_HOME}/etc/Rprofile.site" \
+RUN echo "options(repos = c(CRAN = '$CRAN_REPO'), pkg.sysreqs = FALSE)" >> "${R_HOME}/etc/Rprofile.site" \
       # install packages for dependency resolution and installation
       && Rscript -e "install.packages('pak'); pak::pkg_install('renv')"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,11 +42,9 @@ RUN apt-get update \
 
 # set frozen CRAN repo
 ARG CRAN_REPO="https://packagemanager.posit.co/cran/__linux__/jammy/2023-10-30"
-RUN echo "options(repos = c(CRAN = '$CRAN_REPO'))" >> "${R_HOME}/etc/Rprofile.site"
-
-# install packages for dependency resolution and installation
-RUN Rscript -e "install.packages('pak')"
-RUN Rscript -e "pak::pkg_install('renv')"
+RUN echo "options(repos = c(CRAN = '$CRAN_REPO'))" >> "${R_HOME}/etc/Rprofile.site" \
+      # install packages for dependency resolution and installation
+      && Rscript -e "install.packages('pak'); pak::pkg_install('renv')"
 
 # copy in everything from this repo
 COPY . /

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,15 +28,13 @@ ARG DEBIAN_FRONTEND="noninteractive"
 ARG DEBCONF_NOWARNINGS="yes"
 
 # install system dependencies
-ARG SYS_DEPS="\
-    git \
-    libcurl4-openssl-dev \
-    libssl-dev \
-    openssh-client \
-    wget \
-    "
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends $SYS_DEPS \
+    && apt-get install -y --no-install-recommends \
+      git \
+      libcurl4-openssl-dev \
+      libssl-dev \
+      openssh-client \
+      wget \
     && chmod -R a+rwX /root \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,10 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
       git=1:2.34.* \
       libcurl4-openssl-dev=7.81.* \
+      libicu-dev=70.* \
       libssl-dev=3.0.* \
       openssh-client=1:8.* \
+      pandoc=2.9.2.* \
       wget=1.21.* \
     && chmod -R a+rwX /root \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,11 +30,11 @@ ARG DEBCONF_NOWARNINGS="yes"
 # install system dependencies
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-      git \
-      libcurl4-openssl-dev \
-      libssl-dev \
-      openssh-client \
-      wget \
+      git=1:2.34.* \
+      libcurl4-openssl-dev=7.81.* \
+      libssl-dev=3.0.* \
+      openssh-client=1:8.* \
+      wget=1.21.* \
     && chmod -R a+rwX /root \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 
 # set proper base image
 ARG R_VERS="4.3.1"
-FROM rocker/r-ver:$R_VERS
+FROM rocker/r-ver:$R_VERS AS base
 
 # set Docker image labels
 LABEL org.opencontainers.image.source=https://github.com/RMI-PACTA/workflow.pacta
@@ -45,6 +45,8 @@ ARG CRAN_REPO="https://packagemanager.posit.co/cran/__linux__/jammy/2023-10-30"
 RUN echo "options(repos = c(CRAN = '$CRAN_REPO'), pkg.sysreqs = FALSE)" >> "${R_HOME}/etc/Rprofile.site" \
       # install packages for dependency resolution and installation
       && Rscript -e "install.packages('pak'); pak::pkg_install('renv')"
+
+FROM base AS install-pacta
 
 # copy in everything from this repo
 COPY . /


### PR DESCRIPTION
use buildx `--no-cache-filter` with multistage builds to not cache the installation of PACTA packages, but keep the cache for everything else (like system deps)

Depends on #14 as base for dockerfile to split into stages.
Depends on #15 to ignore `.git` and `.github` directories
Depends on #12 to use `docker buildx`