### PR TITLE
Docker build action specifies `amd64` and `arm64` as `buildx` targets

### DIFF
--- a/.github/workflows/build-and-push-Docker-image.yml
+++ b/.github/workflows/build-and-push-Docker-image.yml
@@ -42,6 +42,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with: 
+          platforms: linux/amd64,linux/arm64
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3


### PR DESCRIPTION
Maybe closes #29 