### PR TITLE
build(Docker): #39 Allow caching R Dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,3 +1,5 @@
+Package: workflow.pacta
+Version: 0.0.0.9000
 Type: PACTA
 Description: Run PACTA.
 Depends:
@@ -9,3 +11,8 @@ Depends:
   pacta.portfolio.import,
   pacta.portfolio.utils,
   readr
+Remotes:
+  RMI-PACTA/pacta.portfolio.allocate,
+  RMI-PACTA/pacta.portfolio.audit,
+  RMI-PACTA/pacta.portfolio.import,
+  RMI-PACTA/pacta.portfolio.utils


### PR DESCRIPTION
Change flow for installing R dependencies, so they are defined in DESCRIPTION and installed using pak. Then in a separate build step, install the latest versions of any relevant pacta.* packages.

Closes: #39