### PR TITLE
Dockerfile Cleaning

### DIFF
--- a/.github/workflows/build-Docker-image-triggers.yml
+++ b/.github/workflows/build-Docker-image-triggers.yml
@@ -12,7 +12,7 @@ name: docker
 jobs:
   docker:
     name: Docker actions
-    uses: RMI-PACTA/actions/.github/workflows/docker.yml@build/improve-docker-labels
+    uses: RMI-PACTA/actions/.github/workflows/docker.yml@main
 
   test:
     name: Test

--- a/.github/workflows/build-Docker-image-triggers.yml
+++ b/.github/workflows/build-Docker-image-triggers.yml
@@ -12,7 +12,7 @@ name: docker
 jobs:
   docker:
     name: Docker actions
-    uses: RMI-PACTA/actions/.github/workflows/docker.yml@main
+    uses: RMI-PACTA/actions/.github/workflows/docker.yml@build/improve-docker-labels
 
   test:
     name: Test

--- a/.github/workflows/build-Docker-image-triggers.yml
+++ b/.github/workflows/build-Docker-image-triggers.yml
@@ -12,7 +12,7 @@ name: docker
 jobs:
   docker:
     name: Docker actions
-    uses: RMI-PACTA/actions/.github/workflows/docker.yml@build/improve-docker-labels
+    uses: RMI-PACTA/actions/.github/workflows/docker.yml@build/improve-docker-labels 
 
   test:
     name: Test

--- a/.github/workflows/build-Docker-image-triggers.yml
+++ b/.github/workflows/build-Docker-image-triggers.yml
@@ -12,7 +12,7 @@ name: docker
 jobs:
   docker:
     name: Docker actions
-    uses: RMI-PACTA/actions/.github/workflows/docker.yml@build/improve-docker-labels 
+    uses: RMI-PACTA/actions/.github/workflows/docker.yml@build/improve-docker-labels
 
   test:
     name: Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
           --network none \
           --env LOG_LEVEL=DEBUG \
           --mount type=bind,readonly,source=${WORKSPACE}/${PACTA_DATA_DIR},target=/pacta-data \
-          --mount type=bind,source=${WORKSPACE}/${OUTPUT_DIR},target=/output_dir \
+          --mount type=bind,source=${WORKSPACE}/${OUTPUT_DIR},target=/home/workflow-pacta/output_dir \
           --mount type=bind,source=${WORKSPACE}/${INPUT_DIR},target=/input_dir \
           $FULL_IMAGE_NAME \
           $PARAMETERS

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,7 @@ jobs:
           WORKSPACE: ${{ github.workspace }}
           PARAMETERS: ${{ steps.prepare.outputs.parameters }}
         run: |
-          chmod -R 777 "${WORKSPACE}/${OUTPUTS_DIR}"
+          chmod -R 777 "${WORKSPACE}/${OUTPUT_DIR}"
           docker run \
           --network none \
           --env LOG_LEVEL=DEBUG \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,6 +82,7 @@ jobs:
           WORKSPACE: ${{ github.workspace }}
           PARAMETERS: ${{ steps.prepare.outputs.parameters }}
         run: |
+          chmod -R 777 "${WORKSPACE}/${OUTPUTS_DIR}"
           docker run \
           --network none \
           --env LOG_LEVEL=DEBUG \

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,15 +35,14 @@ RUN PACKAGE_PIN_DATE="2023-10-30" && \
     CRAN_LIKE_URL="https://packagemanager.posit.co/cran/$PACKAGE_PIN_DATE"; \
   fi && \
   echo "CRAN_LIKE_URL: $CRAN_LIKE_URL" && \
-  printf "options( \
-    repos = c(CRAN = \"$CRAN_LIKE_URL\"), \
-    pkg.sysreqs = FALSE, \
-    pkg.sysreqs_db_update = FALSE, \
-    pkg.sysreqs_update = FALSE \
+  printf "options(\n \
+    repos = c(CRAN = \"%s\"),\n \
+    pkg.sysreqs = FALSE,\n \
+    pkg.sysreqs_db_update = FALSE,\n \
+    pkg.sysreqs_update = FALSE\n \
   )" \
+  "$CRAN_LIKE_URL" \
   > "${R_HOME}/etc/Rprofile.site"
-
-RUN cat "${R_HOME}/etc/Rprofile.site"
 
 # copy in DESCRIPTION from this repo
 COPY DESCRIPTION /workflow.pacta/DESCRIPTION

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,8 @@ LABEL org.opencontainers.image.source=https://github.com/RMI-PACTA/workflow.pact
 LABEL org.opencontainers.image.description="Docker image to run PACTA analysis"
 LABEL org.opencontainers.image.licenses=MIT
 LABEL org.opencontainers.image.title="workflow.pacta"
-LABEL org.opencontainers.image.revision=""
-LABEL org.opencontainers.image.version=""
 LABEL org.opencontainers.image.vendor="RMI"
 LABEL org.opencontainers.image.base.name="docker.io/rocker/r-ver:4.3.1"
-LABEL org.opencontainers.image.ref.name=""
 LABEL org.opencontainers.image.authors="Alex Axthelm, CJ Yetman, Jackson Hoffart"
 
 # set apt-get to noninteractive mode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/r-ver:4.3.1 AS base
+FROM docker.io/rocker/r-ver:4.3.1 AS base
 
 # set Docker image labels
 LABEL org.opencontainers.image.source=https://github.com/RMI-PACTA/workflow.pacta
@@ -8,7 +8,7 @@ LABEL org.opencontainers.image.title="workflow.pacta"
 LABEL org.opencontainers.image.revision=""
 LABEL org.opencontainers.image.version=""
 LABEL org.opencontainers.image.vendor="RMI"
-LABEL org.opencontainers.image.base.name=""
+LABEL org.opencontainers.image.base.name="docker.io/rocker/r-ver:4.3.1"
 LABEL org.opencontainers.image.ref.name=""
 LABEL org.opencontainers.image.authors="Alex Axthelm, CJ Yetman, Jackson Hoffart"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,11 +67,12 @@ COPY . /workflow.pacta/
 
 RUN Rscript -e "pak::local_install(root = '/workflow.pacta')"
 
+# set default run behavior
+ENTRYPOINT ["Rscript", "--vanilla", "/workflow.pacta/inst/extdata/scripts/run_pacta.R"]
+CMD ["/workflow.pacta/input_dir/default_config.json"]
+
 # Create and use non-root user
 RUN useradd -m -s /bin/bash workflow-pacta
 USER workflow-pacta
 WORKDIR /home/workflow-pacta
 
-# set default run behavior
-ENTRYPOINT ["Rscript", "--vanilla", "/workflow.pacta/inst/extdata/scripts/run_pacta.R"]
-CMD ["/workflow.pacta/input_dir/default_config.json"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN PACKAGE_PIN_DATE="2023-10-30" && \
   echo "CRAN_LIKE_URL: $CRAN_LIKE_URL" && \
   printf "options(\n \
     repos = c(CRAN = '%s'),\n \
+    pak.no_extra_messages = TRUE\n \
     pkg.sysreqs = FALSE,\n \
     pkg.sysreqs_db_update = FALSE,\n \
     pkg.sysreqs_update = FALSE\n \

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,8 @@ LABEL org.opencontainers.image.authors=""
 
 # install system dependencies
 RUN apt-get update \
-    DEBIAN_FRONTEND="noninteractive" \
-    DEBCONF_NOWARNINGS="yes" \
-    && apt-get install -y --no-install-recommends \
+    && DEBIAN_FRONTEND="noninteractive" \
+    apt-get install -y --no-install-recommends \
       git=1:2.34.* \
       libcurl4-openssl-dev=7.81.* \
       libicu-dev=70.* \

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,8 @@ COPY . /workflow.pacta/
 
 RUN Rscript -e "pak::local_install(root = '/workflow.pacta')"
 
+USER runner-workflow-factset
+
 # set default run behavior
 ENTRYPOINT ["Rscript", "--vanilla", "/workflow.pacta/inst/extdata/scripts/run_pacta.R"]
 CMD ["/workflow.pacta/input_dir/default_config.json"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN PACKAGE_PIN_DATE="2023-10-30" && \
   echo "CRAN_LIKE_URL: $CRAN_LIKE_URL" && \
   printf "options(\n \
     repos = c(CRAN = '%s'),\n \
-    pak.no_extra_messages = TRUE\n \
+    pak.no_extra_messages = TRUE,\n \
     pkg.sysreqs = FALSE,\n \
     pkg.sysreqs_db_update = FALSE,\n \
     pkg.sysreqs_update = FALSE\n \

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # set frozen CRAN repo and RProfile.site
+# This block makes use of the builtin ARG $TARGETPLATFORM (See:
+# https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/
+# ) to pick the correct CRAN-like repo, which will let us target binaries fo
+# supported platforms
 ARG TARGETPLATFORM
 RUN PACKAGE_PIN_DATE="2023-10-30" && \
   echo "TARGETPLATFORM: $TARGETPLATFORM" && \
@@ -36,11 +40,11 @@ RUN PACKAGE_PIN_DATE="2023-10-30" && \
   fi && \
   echo "CRAN_LIKE_URL: $CRAN_LIKE_URL" && \
   printf "options(\n \
-    repos = c(CRAN = \"%s\"),\n \
+    repos = c(CRAN = '%s'),\n \
     pkg.sysreqs = FALSE,\n \
     pkg.sysreqs_db_update = FALSE,\n \
     pkg.sysreqs_update = FALSE\n \
-  )" \
+  )\n" \
   "$CRAN_LIKE_URL" \
   > "${R_HOME}/etc/Rprofile.site"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,10 @@ COPY . /workflow.pacta/
 
 RUN Rscript -e "pak::local_install(root = '/workflow.pacta')"
 
-USER runner-workflow-factset
+# Create and use non-root user
+RUN useradd -m -s /bin/bash workflow-pacta
+USER workflow-pacta
+WORKDIR /home/workflow-pacta
 
 # set default run behavior
 ENTRYPOINT ["Rscript", "--vanilla", "/workflow.pacta/inst/extdata/scripts/run_pacta.R"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,15 @@ FROM rocker/r-ver:4.3.1 AS base
 
 # set Docker image labels
 LABEL org.opencontainers.image.source=https://github.com/RMI-PACTA/workflow.pacta
-LABEL org.opencontainers.image.description="Docker image to run PACTA"
+LABEL org.opencontainers.image.description="Docker image to run PACTA analysis"
 LABEL org.opencontainers.image.licenses=MIT
-LABEL org.opencontainers.image.title=""
+LABEL org.opencontainers.image.title="workflow.pacta"
 LABEL org.opencontainers.image.revision=""
 LABEL org.opencontainers.image.version=""
-LABEL org.opencontainers.image.vendor=""
+LABEL org.opencontainers.image.vendor="RMI"
 LABEL org.opencontainers.image.base.name=""
 LABEL org.opencontainers.image.ref.name=""
-LABEL org.opencontainers.image.authors=""
+LABEL org.opencontainers.image.authors="Alex Axthelm, CJ Yetman, Jackson Hoffart"
 
 # set apt-get to noninteractive mode
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
         read_only: true
       - type: bind
         source: ${output_dir:-./output_dir}
-        target: /output_dir
+        target: /home/workflow-pacta/output_dir
         read_only: false
       - type: bind
         source: ${input_dir:-./input_dir}

--- a/input_dir/default_config.json
+++ b/input_dir/default_config.json
@@ -1,7 +1,7 @@
 {
   "data_dir": "/pacta-data/2023Q4",
   "portfolio_path": "/workflow.pacta/input_dir/default_portfolio.csv",
-  "output_dir": "output_dir",
+  "output_dir": "/output_dir",
   "start_year": 2023,
   "equity_market_list": ["GlobalMarket", "DevelopedMarket", "EmergingMarket"],
   "scenario_sources_list": ["GECO2023", "ISF2023", "WEO2023"],

--- a/input_dir/default_config.json
+++ b/input_dir/default_config.json
@@ -1,7 +1,7 @@
 {
   "data_dir": "/pacta-data/2023Q4",
   "portfolio_path": "/workflow.pacta/input_dir/default_portfolio.csv",
-  "output_dir": "/output_dir",
+  "output_dir": "/home/workflow-pacta/output_dir",
   "start_year": 2023,
   "equity_market_list": ["GlobalMarket", "DevelopedMarket", "EmergingMarket"],
   "scenario_sources_list": ["GECO2023", "ISF2023", "WEO2023"],

--- a/input_dir/default_config.json
+++ b/input_dir/default_config.json
@@ -1,6 +1,6 @@
 {
   "data_dir": "/pacta-data/2023Q4",
-  "portfolio_path": "input_dir/default_portfolio.csv",
+  "portfolio_path": "/workflow.pacta/input_dir/default_portfolio.csv",
   "output_dir": "output_dir",
   "start_year": 2023,
   "equity_market_list": ["GlobalMarket", "DevelopedMarket", "EmergingMarket"],

--- a/input_dir/default_config.json
+++ b/input_dir/default_config.json
@@ -1,5 +1,5 @@
 {
-  "data_dir": "../pacta-data/2023Q4",
+  "data_dir": "/pacta-data/2023Q4",
   "portfolio_path": "input_dir/default_portfolio.csv",
   "output_dir": "output_dir",
   "start_year": 2023,

--- a/tests/config/default_2022Q4.json
+++ b/tests/config/default_2022Q4.json
@@ -3,7 +3,7 @@
   "pactaDataURL": "https://pactadatadev.file.core.windows.net/workflow-data-preparation-outputs/2022Q4_20240426T113151Z",
   "parameters": {
     "data_dir": "/pacta-data/2022Q4",
-    "portfolio_path": "input_dir/default_portfolio.csv",
+    "portfolio_path": "/workflow.pacta/input_dir/default_portfolio.csv",
     "output_dir": "output_dir",
     "start_year": 2022,
     "equity_market_list": ["GlobalMarket", "DevelopedMarket", "EmergingMarket"],

--- a/tests/config/default_2022Q4.json
+++ b/tests/config/default_2022Q4.json
@@ -4,7 +4,7 @@
   "parameters": {
     "data_dir": "/pacta-data/2022Q4",
     "portfolio_path": "/workflow.pacta/input_dir/default_portfolio.csv",
-    "output_dir": "/output_dir",
+    "output_dir": "/home/workflow-pacta/output_dir",
     "start_year": 2022,
     "equity_market_list": ["GlobalMarket", "DevelopedMarket", "EmergingMarket"],
     "scenario_sources_list": ["GECO2022", "ISF2021", "WEO2022"],

--- a/tests/config/default_2022Q4.json
+++ b/tests/config/default_2022Q4.json
@@ -4,7 +4,7 @@
   "parameters": {
     "data_dir": "/pacta-data/2022Q4",
     "portfolio_path": "/workflow.pacta/input_dir/default_portfolio.csv",
-    "output_dir": "output_dir",
+    "output_dir": "/output_dir",
     "start_year": 2022,
     "equity_market_list": ["GlobalMarket", "DevelopedMarket", "EmergingMarket"],
     "scenario_sources_list": ["GECO2022", "ISF2021", "WEO2022"],

--- a/tests/config/default_2022Q4.json
+++ b/tests/config/default_2022Q4.json
@@ -2,7 +2,7 @@
   "holdingsDate": "2022Q4",
   "pactaDataURL": "https://pactadatadev.file.core.windows.net/workflow-data-preparation-outputs/2022Q4_20240426T113151Z",
   "parameters": {
-    "data_dir": "../pacta-data/2022Q4",
+    "data_dir": "/pacta-data/2022Q4",
     "portfolio_path": "input_dir/default_portfolio.csv",
     "output_dir": "output_dir",
     "start_year": 2022,


### PR DESCRIPTION
Cleaning up the Dockerfile!

The biggest structural change here is in the block that writes `Rprofile.site`. That now uses the builtin `TARGETPLATFORM` build arg ([more info](https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/)) to determine if we should be pulling Binaries (for Ubuntu Jammy) or building packages from source (everything else).

The other notable change is cleaning up the `LABEL` instructions, which in conjunction with https://github.com/RMI-PACTA/actions/pull/85 provides up to date labels, including `revision` and `version`.

Smaller Changes:
* Don't use `root` as user
* hardcoding the image tag for the base image, rather than having be a build arg
* fully qualifying the base image (`docker.io/rocker/r-ver`, rather than `rocker/r-ver`)
* Moving the `DEBIAN_FRONTEND` from build args to inline envvar
* Adding more R `options` to control behavior of `pak` and `pkgload`
* copying package source code to `/workflow.pacta` instead of system root dir.

- [x] Depends on https://github.com/RMI-PACTA/actions/pull/85

Closes #55 
Closes #46 