### PR TITLE
bug: update `startYear` value to be aligned with config date

### DIFF
--- a/tests/config/full_params_2023Q4.json
+++ b/tests/config/full_params_2023Q4.json
@@ -34,7 +34,7 @@
         "Aviation",
         "Cement"
       ],
-      "startYear": 2022,
+      "startYear": 2023,
       "timeHorizon": 5
     }
   }


### PR DESCRIPTION
Everything else points to `2023`, but `startYear = 2022`

Maybe closes #103 