### PR TITLE
disable ARM build of docker image,

### DIFF
--- a/.github/workflows/build-Docker-image-triggers.yml
+++ b/.github/workflows/build-Docker-image-triggers.yml
@@ -13,6 +13,12 @@ jobs:
   docker:
     name: Docker actions
     uses: RMI-PACTA/actions/.github/workflows/docker.yml@main
+    with:
+      build-platform:
+          [
+            "linux/amd64"
+          ]
+
 
   test:
     name: Test


### PR DESCRIPTION
due to long build times (>90 min), which cause CI to time out, disable this rarely used image build